### PR TITLE
Fix untitled title

### DIFF
--- a/lib/makdoc.js
+++ b/lib/makdoc.js
@@ -96,7 +96,6 @@ makdoc.model.init = function() {
         }
 
         file.model = {
-            title: 'untitled',
             date: new Date(),
             description: '',
             keywords: []


### PR DESCRIPTION
In layout page, if content of title tag is
'<title>{{{-find '-not-empty?' (-array title package.title)}}}</title>'
, 'untitled' is rendered.

Remove default 'untitled' title of a model.
